### PR TITLE
Add title attribute on OAS's request/response scheme

### DIFF
--- a/src/Builders/ToOAS.php
+++ b/src/Builders/ToOAS.php
@@ -157,6 +157,9 @@ class ToOAS extends AbstractBuilder
             if (is_array($response)) {
                 $response = $this->buildSwaggerObject($response);
             }
+
+            $response['title'] = $path . '_' . $this->method . '_response_' . $this->response->status();
+
             $content['paths'][$path][strtolower($this->method)]['responses'][$this->response->status()]["content"] = [
                 "application/json" => [
                     "schema" => $response,
@@ -164,10 +167,14 @@ class ToOAS extends AbstractBuilder
             ];
         }
         if ($this->data) {
+            $requestBody = $this->buildSwaggerObject($this->data);
+
+            $requestBody['title'] = $path . '_' . $this->method . '_request';
+
             $content['paths'][$path][strtolower($this->method)]['requestBody'] = [
                 "content" => [
                     "application/json" => [
-                        "schema" => $this->buildSwaggerObject($this->data),
+                        "schema" => $requestBody,
                     ],
                 ],
             ];

--- a/test/Builders/data/ToOASTest/TestGenerateContent_GET.expected.json
+++ b/test/Builders/data/ToOASTest/TestGenerateContent_GET.expected.json
@@ -17,6 +17,7 @@
                         "content": {
                             "application\/json": {
                                 "schema": {
+                                    "title": "/user/1_GET_response_200",
                                     "type": "object",
                                     "properties": {
                                         "name": {

--- a/test/Builders/data/ToOASTest/TestGenerateContent_WithData.expected.json
+++ b/test/Builders/data/ToOASTest/TestGenerateContent_WithData.expected.json
@@ -21,6 +21,7 @@
                         "content": {
                             "application\/json": {
                                 "schema": {
+                                    "title": "/user_POST_response_200",
                                     "type": "object",
                                     "properties": {
                                         "name": {
@@ -50,6 +51,7 @@
                     "content": {
                         "application\/json": {
                             "schema": {
+                                "title": "/user_POST_request",
                                 "type": "object",
                                 "properties": {
                                     "name": {


### PR DESCRIPTION
OAS generator infers request/response's name of type with `title` attribute.

Using the code created by the OAS generator, you can use the type definitions as shown below.
```typescript
    // generated from https://raw.githubusercontent.com/kotamat/laravel-apispec-generator/e62e266c00af7a8a1084e6ea5c7025a4a89289c1/test/Builders/data/ToOASTest/TestGenerateContent_WithData.expected.json
    const api = new DefaultApi()
    const param: UserPOSTRequest = {name: ""}
    const response = await api.userPOST({userPOSTRequest: param})
    const data: UserPOSTResponse200 = response.data
```